### PR TITLE
[recipe show] tweak moweb css

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -5,6 +5,10 @@ $warn: "pink";
 
 @import 'ember-paper';
 
+* {
+  box-sizing: border-box;
+}
+
 .inline-block {
   display: inline-block;
 }
@@ -41,6 +45,15 @@ $warn: "pink";
 
 .toolbar-padding {
   padding-top: 64px;
+
+  @media (max-width: 959px) and (min-width: 0) and (orientation: landscape) {
+    padding-top: 48px;
+  }
+
+  @media (max-width: 959px) and (min-width: 0) and (orientation: portrait) {
+    padding-top: 56px;
+  }
+
   @media print {
     padding-top: 0;
   }
@@ -128,4 +141,13 @@ $warn: "pink";
 
 .recipe-show__container {
   padding: 0px 32px;
+  word-wrap: break-word;
+}
+
+.recipe-show__title {
+  // truncate title at 2 lines
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/app/templates/components/recipe-show.hbs
+++ b/app/templates/components/recipe-show.hbs
@@ -4,7 +4,7 @@
       {{paper-button label="Go Back"}}
     {{/link-to}}
     <span class="flex"></span>
-    <h1>{{recipe.name}}</h1>
+    <h1 class="recipe-show__title">{{recipe.name}}</h1>
     <span class="flex"></span>
     {{#if canEdit}}
       {{#link-to "recipes.edit" recipe.id}}


### PR DESCRIPTION
Posting this PR on behalf of @byteme980

This PR makes the following changes:
* Update toolbar padding to account for ember-paper responsive height changes
* Truncate recipe detail marquee title at 2 lines 
* Add `box-sizing: border-box` rule for all elements

